### PR TITLE
Support Token-2022 sends, track token-account creation, fix SPL counterparty

### DIFF
--- a/Sources/SolanaKit/Database/TransactionStorage.swift
+++ b/Sources/SolanaKit/Database/TransactionStorage.swift
@@ -109,6 +109,12 @@ final class TransactionStorage {
             }
         }
 
+        migrator.registerMigration("addCreatedTokenAccountToTransactions") { db in
+            try db.alter(table: Transaction.databaseTableName) { t in
+                t.add(column: Transaction.Columns.createdTokenAccount.name, .boolean)
+            }
+        }
+
         return migrator
     }
 

--- a/Sources/SolanaKit/Models/Transaction.swift
+++ b/Sources/SolanaKit/Models/Transaction.swift
@@ -35,6 +35,11 @@ public class Transaction: Record {
     /// the Jupiter aggregator — lets clients classify swaps ("Swapped via Jupiter") instead of
     /// rendering an unknown multi-transfer transaction. `nil` when none were recognized.
     public var programIds: String?
+    /// Whether this transaction invoked the Associated Token Account program (i.e. created a token
+    /// account, paying ~0.002 SOL of rent). NULL means "unknown" — a row stored before this was
+    /// tracked — for which clients should fall back to an amount heuristic rather than assume no
+    /// account was made.
+    public var createdTokenAccount: Bool?
 
     /// Transaction fee as `Decimal`, or `nil` if `fee` is not set.
     public var decimalFee: Decimal? {
@@ -61,7 +66,8 @@ public class Transaction: Record {
         lastValidBlockHeight: Int64 = 0,
         base64Encoded: String = "",
         retryCount: Int = 0,
-        programIds: String? = nil
+        programIds: String? = nil,
+        createdTokenAccount: Bool? = nil
     ) {
         self.hash = hash
         self.timestamp = timestamp
@@ -76,6 +82,7 @@ public class Transaction: Record {
         self.base64Encoded = base64Encoded
         self.retryCount = retryCount
         self.programIds = programIds
+        self.createdTokenAccount = createdTokenAccount
         super.init()
     }
 
@@ -102,6 +109,7 @@ public class Transaction: Record {
         case base64Encoded
         case retryCount
         case programIds
+        case createdTokenAccount
     }
 
     public required init(row: Row) throws {
@@ -118,6 +126,7 @@ public class Transaction: Record {
         base64Encoded = row[Columns.base64Encoded]
         retryCount = row[Columns.retryCount]
         programIds = row[Columns.programIds]
+        createdTokenAccount = row[Columns.createdTokenAccount]
         try super.init(row: row)
     }
 
@@ -135,5 +144,6 @@ public class Transaction: Record {
         container[Columns.base64Encoded] = base64Encoded
         container[Columns.retryCount] = retryCount
         container[Columns.programIds] = programIds
+        container[Columns.createdTokenAccount] = createdTokenAccount
     }
 }

--- a/Sources/SolanaKit/Programs/AssociatedTokenAccountProgram.swift
+++ b/Sources/SolanaKit/Programs/AssociatedTokenAccountProgram.swift
@@ -18,12 +18,14 @@ enum AssociatedTokenAccountProgram {
     /// - Parameters:
     ///   - wallet: The wallet public key that owns the ATA.
     ///   - mint: The token mint public key.
+    ///   - tokenProgramId: The program owning the mint (`.tokenProgramId` or `.token2022ProgramId`) —
+    ///     part of the PDA seeds, so a Token-2022 mint yields a DIFFERENT address than classic.
     /// - Returns: The derived ATA `PublicKey` (bump seed is discarded).
     /// - Throws: `PublicKey.PDAError` if no valid address is found.
-    static func associatedTokenAddress(wallet: PublicKey, mint: PublicKey) throws -> PublicKey {
+    static func associatedTokenAddress(wallet: PublicKey, mint: PublicKey, tokenProgramId: PublicKey) throws -> PublicKey {
         let seeds: [Data] = [
             wallet.data,
-            PublicKey.tokenProgramId.data,
+            tokenProgramId.data,
             mint.data,
         ]
         let (address, _) = try PublicKey.findProgramAddress(seeds: seeds, programId: .associatedTokenProgramId)
@@ -59,7 +61,8 @@ enum AssociatedTokenAccountProgram {
         payer: PublicKey,
         associatedToken: PublicKey,
         owner: PublicKey,
-        mint: PublicKey
+        mint: PublicKey,
+        tokenProgramId: PublicKey
     ) -> TransactionInstruction {
         // Instruction index 1 = CreateIdempotent.
         let data = Data([1])
@@ -70,7 +73,7 @@ enum AssociatedTokenAccountProgram {
             AccountMeta(publicKey: owner,                          isSigner: false, isWritable: false),
             AccountMeta(publicKey: mint,                           isSigner: false, isWritable: false),
             AccountMeta(publicKey: .systemProgramId,               isSigner: false, isWritable: false),
-            AccountMeta(publicKey: .tokenProgramId,                isSigner: false, isWritable: false),
+            AccountMeta(publicKey: tokenProgramId,                 isSigner: false, isWritable: false),
             AccountMeta(publicKey: .sysvarRentProgramId,           isSigner: false, isWritable: false),
         ]
 

--- a/Sources/SolanaKit/Programs/KnownPrograms.swift
+++ b/Sources/SolanaKit/Programs/KnownPrograms.swift
@@ -15,8 +15,18 @@ public enum KnownPrograms {
     /// LI.FI executor program (logs "LI.FI TX"); the entry point of a LI.FI Solana swap/bridge.
     public static let lifi = "3i5JeuZuUxeKtVysUnwQNGerJP2bSMX9fTFfS4Nxe3Br"
 
+    /// DFlow aggregator. Jupiter routes some swap legs through DFlow, so a single Jupiter swap can
+    /// land on-chain as two transactions — one via Jupiter v6, one via DFlow — and the DFlow leg
+    /// must be recognized too or it renders as an unknown multi-transfer.
+    public static let dflow = "DF1ow4tspfHX9JwWJsAb9epbkA8hmpSEAtxXy1V27QBH"
+
+    /// SPL Associated Token Account program. Not part of `all` — it is not a swap and must not be
+    /// surfaced on `Transaction.programIds` — but its presence among a transaction's INVOKED
+    /// programs means the transaction created a token account, paying ~0.002 SOL of rent.
+    public static let associatedTokenAccount = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+
     /// All recognized program ids.
-    public static let all: Set<String> = [jupiterV6, lifi]
+    public static let all: Set<String> = [jupiterV6, lifi, dflow]
 
     /// The recognized subset of `candidates`, deduplicated (first occurrence wins, order
     /// preserved) and space-joined for `Transaction.programIds`; `nil` when none are recognized.
@@ -26,5 +36,13 @@ public enum KnownPrograms {
         var seen = Set<String>()
         let hits = candidates.filter { all.contains($0) && seen.insert($0).inserted }
         return hits.isEmpty ? nil : hits.joined(separator: " ")
+    }
+
+    /// Whether `invokedProgramIds` (INVOKED program ids, one per instruction — the same input as
+    /// `recognized`) shows this transaction created an associated token account. Only top-level
+    /// invocations are visible to callers, which covers wallet-built SPL sends that prepend a
+    /// create-ATA instruction; an ATA created via CPI inside another program is not detected.
+    static func createsTokenAccount(in invokedProgramIds: [String]) -> Bool {
+        invokedProgramIds.contains(associatedTokenAccount)
     }
 }

--- a/Sources/SolanaKit/Programs/TokenProgram.swift
+++ b/Sources/SolanaKit/Programs/TokenProgram.swift
@@ -85,7 +85,8 @@ enum TokenProgram {
         destination: PublicKey,
         authority: PublicKey,
         amount: UInt64,
-        decimals: UInt8
+        decimals: UInt8,
+        tokenProgramId: PublicKey
     ) -> TransactionInstruction {
         var data = Data()
 
@@ -107,7 +108,7 @@ enum TokenProgram {
         ]
 
         return TransactionInstruction(
-            programId: .tokenProgramId,
+            programId: tokenProgramId,
             keys: keys,
             data: data
         )

--- a/Sources/SolanaKit/Transactions/TransactionManager.swift
+++ b/Sources/SolanaKit/Transactions/TransactionManager.swift
@@ -176,6 +176,7 @@ final class TransactionManager {
                 // Freshly derived tag wins (the stored one may predate the program joining
                 // KnownPrograms); fall back to the stored value when the sync derived none.
                 merged.programIds = tx.programIds ?? merged.programIds
+                merged.createdTokenAccount = tx.createdTokenAccount ?? merged.createdTokenAccount
                 mergedTransactions.append(merged)
 
                 // If synced has no token transfers but DB has some, collect their mint
@@ -322,12 +323,31 @@ final class TransactionManager {
         guard let senderFullTokenAccount = storage.fullTokenAccount(mintAddress: mintAddress) else {
             throw SendError.tokenAccountNotFound(mintAddress)
         }
-        let senderATA = try PublicKey(senderFullTokenAccount.tokenAccount.address)
 
-        // 2. Derive recipient's ATA address.
+        // 2. A mint is Token-2022 when its account is owned by the Token-2022 program. Resolved at
+        //    send time (mirrors Android): a missing account reads as classic, an RPC failure fails
+        //    the send.
+        let mintInfos = try await rpcApiProvider.getMultipleAccounts(addresses: [mintAddress])
+        let isToken2022 = mintInfos.first.flatMap { $0 }?.owner == PublicKey.token2022ProgramId.base58
+        let tokenProgramId: PublicKey = isToken2022 ? .token2022ProgramId : .tokenProgramId
+
+        // 3. Resolve source and destination token accounts. Token-2022 derives BOTH with the
+        //    Token-2022 program id in the PDA seeds (as Android's Token2022Sender); classic keeps
+        //    the stored sender account.
+        let senderATA: PublicKey
+        if isToken2022 {
+            senderATA = try AssociatedTokenAccountProgram.associatedTokenAddress(
+                wallet: senderPublicKey,
+                mint: mintPublicKey,
+                tokenProgramId: tokenProgramId
+            )
+        } else {
+            senderATA = try PublicKey(senderFullTokenAccount.tokenAccount.address)
+        }
         let recipientATA = try AssociatedTokenAccountProgram.associatedTokenAddress(
             wallet: recipientPublicKey,
-            mint: mintPublicKey
+            mint: mintPublicKey,
+            tokenProgramId: tokenProgramId
         )
 
         // Guard: sender and recipient ATAs must differ.
@@ -335,30 +355,45 @@ final class TransactionManager {
             throw SendError.sameSourceAndDestination
         }
 
-        // 3. Check whether recipient's ATA exists on-chain.
+        // 4. Check whether recipient's ATA exists on-chain.
         let recipientATAAccounts = try await rpcApiProvider.getMultipleAccounts(addresses: [recipientATA.base58])
         // `getMultipleAccounts` returns `[BufferInfo?]`; a non-nil inner element means the account exists.
         let recipientATAExists = recipientATAAccounts.first.flatMap { $0 } != nil
 
-        // 4. Fetch recent blockhash.
+        // 5. Fetch recent blockhash.
         let blockhashResponse = try await rpcApiProvider.getLatestBlockhash()
 
-        // 5. Build instructions.
+        // 6. Build instructions.
         var instructions: [TransactionInstruction] = priorityFeeInstructions()
         if !recipientATAExists {
             instructions.append(AssociatedTokenAccountProgram.createIdempotent(
                 payer: senderPublicKey,
                 associatedToken: recipientATA,
                 owner: recipientPublicKey,
-                mint: mintPublicKey
+                mint: mintPublicKey,
+                tokenProgramId: tokenProgramId
             ))
         }
-        instructions.append(TokenProgram.transfer(
-            source: senderATA,
-            destination: recipientATA,
-            authority: senderPublicKey,
-            amount: amount
-        ))
+        if isToken2022 {
+            // Fee-bearing Token-2022 mints reject plain Transfer; TransferChecked carries the
+            // mint + decimals the Token-2022 program requires.
+            instructions.append(TokenProgram.transferChecked(
+                source: senderATA,
+                mint: mintPublicKey,
+                destination: recipientATA,
+                authority: senderPublicKey,
+                amount: amount,
+                decimals: UInt8(senderFullTokenAccount.tokenAccount.decimals),
+                tokenProgramId: tokenProgramId
+            ))
+        } else {
+            instructions.append(TokenProgram.transfer(
+                source: senderATA,
+                destination: recipientATA,
+                authority: senderPublicKey,
+                amount: amount
+            ))
+        }
 
         // 6. Serialize, sign, build wire transaction, broadcast.
         let (base64Tx, txHash) = try await serializeSignAndSend(
@@ -379,7 +414,9 @@ final class TransactionManager {
             blockHash: blockhashResponse.blockhash,
             lastValidBlockHeight: blockhashResponse.lastValidBlockHeight,
             base64Encoded: base64Tx,
-            retryCount: 0
+            retryCount: 0,
+            // Known exactly here (unlike synced rows, which infer it from invoked programs).
+            createdTokenAccount: !recipientATAExists
         )
         let tokenTransfer = TokenTransfer(
             transactionHash: txHash,
@@ -509,7 +546,8 @@ final class TransactionManager {
             lastValidBlockHeight: blockhashResponse.lastValidBlockHeight,
             base64Encoded: base64Tx,
             retryCount: 0,
-            programIds: KnownPrograms.recognized(in: invokedPrograms)
+            programIds: KnownPrograms.recognized(in: invokedPrograms),
+            createdTokenAccount: KnownPrograms.createsTokenAccount(in: invokedPrograms)
         )
 
         // 10. Persist and emit.

--- a/Sources/SolanaKit/Transactions/TransactionSyncer.swift
+++ b/Sources/SolanaKit/Transactions/TransactionSyncer.swift
@@ -218,7 +218,23 @@ final class TransactionSyncer {
                 preByKey["\(balance.accountIndex)_\(balance.mint)"] = balance
             }
 
-            let allKeys = Set(postByKey.keys).union(Set(preByKey.keys))
+            // Token accounts of THIS transaction, all owners including ours — the set the
+            // counterparty substitution below checks against.
+            var tokenBalanceAccountKeys = Set<String>()
+            for balance in (meta.postTokenBalances ?? []) + (meta.preTokenBalances ?? []) {
+                let index = balance.accountIndex
+                if index >= 0, index < accountKeys.count {
+                    tokenBalanceAccountKeys.insert(accountKeys[index])
+                }
+            }
+
+            // Deterministic order: Set iteration is unordered in Swift, and both the SPL-only
+            // from/to inference and the counterparty substitution key off the FIRST transfer.
+            let allKeys = Set(postByKey.keys).union(Set(preByKey.keys)).sorted { lhs, rhs in
+                let lhsIndex = Int(lhs.prefix(while: { $0 != "_" })) ?? 0
+                let rhsIndex = Int(rhs.prefix(while: { $0 != "_" })) ?? 0
+                return lhsIndex != rhsIndex ? lhsIndex < rhsIndex : lhs < rhs
+            }
 
             for key in allKeys {
                 let postBalance = postByKey[key]
@@ -274,6 +290,20 @@ final class TransactionSyncer {
                 }
             }
 
+            // A rent-funded token account can win the SOL-balance heuristic (largest increase)
+            // and land in from/to. When the transaction carries token transfers and that SOL
+            // counterparty is one of ITS OWN token accounts, substitute the owner wallet on the
+            // matching side; in every other case the SOL heuristic stands. Mirrors android d72f087.
+            if let primary = tokenTransfers.first {
+                let counterparty = mintCounterparties[primary.mintAddress]
+                if !primary.incoming, let currentTo = solTo, tokenBalanceAccountKeys.contains(currentTo), let receiver = counterparty?.receiver {
+                    solTo = receiver
+                }
+                if primary.incoming, let currentFrom = solFrom, tokenBalanceAccountKeys.contains(currentFrom), let sender = counterparty?.sender {
+                    solFrom = sender
+                }
+            }
+
             // Infer from/to for SPL-only transactions (no SOL counterparty detected).
             // Matches Android: only runs when the SOL balance heuristic produced no result.
             if solFrom == nil, solTo == nil, let primary = tokenTransfers.first {
@@ -289,6 +319,7 @@ final class TransactionSyncer {
         }
 
         let errorString = meta?.err?.description
+        let invokedPrograms = response.transaction?.message?.instructions?.compactMap(\.programId) ?? []
 
         let transaction = Transaction(
             hash: signature,
@@ -304,9 +335,8 @@ final class TransactionSyncer {
             // match transactions that merely reference a program (e.g. the wallet receiving the
             // tail of someone else's Jupiter swap) and, with jsonParsed, lookup-table-loaded
             // addresses. Matches the send-path derivation in TransactionManager step 9.
-            programIds: KnownPrograms.recognized(
-                in: response.transaction?.message?.instructions?.compactMap(\.programId) ?? []
-            )
+            programIds: KnownPrograms.recognized(in: invokedPrograms),
+            createdTokenAccount: KnownPrograms.createsTokenAccount(in: invokedPrograms)
         )
 
         logger?.verbose("TransactionSyncer: tx \(signature) — fee: \(feeString), SOL from: \(solFrom ?? "nil") to: \(solTo ?? "nil"), amount: \(amountString ?? "nil"), tokenTransfers: \(tokenTransfers.count), error: \(errorString ?? "none")")


### PR DESCRIPTION
The send path was hardcoded to the classic SPL Token program: the ATA was derived with the classic program id in the PDA seeds and the transfer targeted the classic program, so Token-2022 mints (owned by a different program, with fee-bearing mints rejecting plain Transfer) could not be sent at all. sendSpl now resolves the mint's owning program at send time and, for Token-2022, derives both ATAs with the Token-2022 program id and emits TransferChecked; the classic path is unchanged.

Transactions now carry a nullable createdTokenAccount flag (set exactly on sends, inferred from invoked programs on synced rows) so clients can tell token-account rent from a real SOL transfer, and the SOL-balance counterparty heuristic no longer reports a freshly rent-funded token account instead of the owner wallet. Token transfer parsing order is made deterministic; the DFlow aggregator is recognized as a swap program.

Mirrors solana-kit-android 2be63c6, 3460323, d72f087, c79c339.